### PR TITLE
ensure Ua vector field data is written in darcyFoam

### DIFF
--- a/solvers/darcyFoam/darcyFoam.C
+++ b/solvers/darcyFoam/darcyFoam.C
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
 
             U = fvc::reconstruct(phi);
             U.correctBoundaryConditions();
-
+            Ua = U;
 	  }
 
         Info << "ExecutionTime = " << runTime.elapsedCpuTime() << " s"


### PR DESCRIPTION
Currently `Ua` vector field information is not written to file. This change allows visualisation of the output vector field.