### PR TITLE
Feature/open suse mingw build

### DIFF
--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -29,7 +29,6 @@ jobs:
         
     - name: Docker file push
       id: docker_push
-      if: steps.changed-files.outputs.modified_files != ''
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: jmkerloch/openfoam-opensuse-mingw

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -28,12 +28,12 @@ jobs:
           docker/opensuse-mingw
         
     - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
-        with:
-          registry: ghcr.io
-          repository: pmf/opensuse-mingw
-          tags: latest
-          dockerfile: docker/opensuse-mingw
+      uses: docker/build-push-action@v1
+      with:
+        registry: ghcr.io
+        repository: pmf/opensuse-mingw
+        tags: latest
+        dockerfile: docker/opensuse-mingw
 
   build:
 

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -47,7 +47,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: docker_publish
-    container: 'ghcr.io/jmkerloch/openfoam-opensuse-mingw'
+    container: 'ghcr.io/${{github.actor}}/porousmultiphasefoam:openfoam-opensuse-mingw'
 
     steps:
     

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -61,10 +61,6 @@ jobs:
           
     - name: Build
       run: |    
-           export PMF_DIR=$pwd
-           FOAM_VERBOSE=true
-           cd /openfoam
-           FOAM_VERBOSE=true  source etc/bashrc etc-mingw/prefs.sh
-           cd $PMF_DIR
-           ./Allwmake -j      
+           FOAM_VERBOSE=true &&  source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh && ls && ./Allwmake -j
+      
       shell: sh

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -30,16 +30,14 @@ jobs:
     - name: Push to GitHub Packages
       uses: docker/build-push-action@v1
       with:
-        registry: ghcr.io
-        repository: jmkerloch/openfoam-opensuse-mingw
-        tags: latest
+        tags: openfoam-opensuse-mingw
         dockerfile: docker/opensuse-mingw
 
   build:
 
     runs-on: ubuntu-latest
     needs: docker_publish
-    container: 'jmkerloch/openfoam-opensuse-mingw'
+    container: 'ghcr.io/jmkerloch/openfoam-opensuse-mingw'
 
     steps:
     

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -60,15 +60,8 @@ jobs:
           git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git -b ${BRANCH_NAME} .
           
     - name: Build
-      run: |           
-           echo $FOAM_CONFIG_ETC
-           echo $WM_COMPILER
-           echo $WM_MPLIB          
-           ls
-           pwd
-           ls /openfoam
+      run: |    
            FOAM_VERBOSE=true
-           source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh
-           echo $FOAM_SETTINGS
+           source /openfoam/etc/bashrc
            ./Allwmake -j      
       shell: bash

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -59,5 +59,5 @@ jobs:
           
     - name: Build
       run: |
-           source etc-mingw/prefs.sh
+           source /openfoam/etc/bashrc etc-mingw/prefs.sh
            ./Allwmake -j

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -60,10 +60,12 @@ jobs:
           git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git -b ${BRANCH_NAME} .
           
     - name: Build
-      run: |
-           FOAM_VERBOSE=true 
+      run: |           
            source etc-mingw/prefs.sh
-           source /openfoam/etc/bashrc           
+           echo $FOAM_CONFIG_ETC
+           echo $WM_COMPILER
+           echo $WM_MPLIB
+           FOAM_VERBOSE=true  source /openfoam/etc/bashrc           
            ls
            pwd
            ls /openfoam

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -64,8 +64,7 @@ jobs:
            source etc-mingw/prefs.sh
            echo $FOAM_CONFIG_ETC
            echo $WM_COMPILER
-           echo $WM_MPLIB
-           FOAM_VERBOSE=true  source /openfoam/etc/bashrc           
+           echo $WM_MPLIB          
            ls
            pwd
            ls /openfoam

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -68,6 +68,8 @@ jobs:
            ls
            pwd
            ls /openfoam
+           FOAM_VERBOSE=true
+           source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh
            echo $FOAM_SETTINGS
            ./Allwmake -j      
       shell: bash

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -61,7 +61,8 @@ jobs:
           
     - name: Build
       run: |
-           FOAM_VERBOSE=true source /openfoam/etc/bashrc etc-mingw/prefs.sh
+           FOAM_VERBOSE=true source /openfoam/etc/bashrc 
+           source etc-mingw/prefs.sh
            ls
            pwd
            ls /openfoam

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -67,4 +67,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: pmf-opensuse-mingw
-        path: /root/OpenFOAM/-v2106/platforms/linux64MingwDPInt32Opt/
+        path: /github/home/OpenFOAM/-v2106/platforms/linux64MingwDPInt32Opt/
+        

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -65,4 +65,5 @@ jobs:
            pwd
            ls /openfoam
            source /openfoam/etc/bashrc etc-mingw/prefs.sh
-           Allwmake -j
+           echo $FOAM_SETTINGS
+           ./Allwmake -j

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -61,8 +61,10 @@ jobs:
           
     - name: Build
       run: |    
-           FOAM_VERBOSE=true &&  source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh && ls && ./Allwmake -j      
-      shell: sh      
-      artifacts:
-        paths:
-          - /root/OpenFOAM/-v2106/platforms/linux64MingwDPInt32Opt/
+           FOAM_VERBOSE=true &&  source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh && ls && ./Allwmake -j
+      
+    - name: Build artifact upload
+      uses: actions/upload-artifact@v2
+      with:
+        name: pmf-opensuse-mingw
+        path: /root/OpenFOAM/-v2106/platforms/linux64MingwDPInt32Opt/

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -67,4 +67,4 @@ jobs:
            FOAM_VERBOSE=true  source etc/bashrc etc-mingw/prefs.sh
            cd $PMF_DIR
            ./Allwmake -j      
-      shell: bash
+      shell: sh

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -62,6 +62,8 @@ jobs:
     - name: Build
       run: |    
            FOAM_VERBOSE=true
-           source /openfoam/etc/bashrc
+           cd openfoam
+           FOAM_VERBOSE=true  source etc/bashrc etc-mingw/prefs.sh
+           cd ..
            ./Allwmake -j      
       shell: bash

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -6,7 +6,7 @@ on:
       - main
       - dev
       - features/*
-      - feature/
+      - feature/*
   
 jobs:
 

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -40,6 +40,8 @@ jobs:
         registry: ghcr.io
         tags: openfoam-opensuse-mingw
         dockerfile: docker/opensuse-mingw
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
   build:
 

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -59,7 +59,5 @@ jobs:
           
     - name: Build
       run: |
-           pwd
-           ls -l
-           source /etc-mingw/prefs.sh
+           source etc-mingw/prefs.sh
            ./Allwmake -j

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -28,6 +28,7 @@ jobs:
           docker/opensuse-mingw
           
     - name: Log in to the Container registry
+      if: steps.changed-files.outputs.modified_files != ''
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -35,6 +36,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
         
     - name: Push to GitHub Packages
+      if: steps.changed-files.outputs.modified_files != ''
       uses: docker/build-push-action@v1
       with:
         registry: ghcr.io

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -61,7 +61,8 @@ jobs:
           
     - name: Build
       run: |
-           source /openfoam/etc/bashrc etc-mingw/prefs.sh
            ls
            pwd
+           ls /openfoam
+           source /openfoam/etc/bashrc etc-mingw/prefs.sh
            ./Allwmake -j

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -27,23 +27,19 @@ jobs:
         files: |
           docker/opensuse-mingw
         
-    - name: Docker file push
-      id: docker_push
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: jmkerloch/openfoam-opensuse-mingw
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        workdir: docker
-        dockerfile: opensuse-mingw
-        cache: true
-        tags: opensuse-mingw
+    - name: Push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          registry: ghcr.io
+          repository: pmf/opensuse-mingw
+          tags: latest
+          dockerfile: docker/opensuse-mingw
 
   build:
 
     runs-on: ubuntu-latest
     needs: docker_publish
-    container: 'jmkerloch/openfoam-opensuse-mingw'
+    container: 'pmf/opensuse-mingw'
 
     steps:
     
@@ -53,7 +49,7 @@ jobs:
       run: |
           git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git -b ${BRANCH_NAME} .
           
-    - name: Configure
+    - name: Build
       run: |
            source /etc-mingw/prefs.sh
            ./Allwmake -j

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -59,6 +59,8 @@ jobs:
           
     - name: Build
       run: |
+           pwd
+	   ls -l
            source /etc-mingw/prefs.sh
            ./Allwmake -j
 

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -61,8 +61,9 @@ jobs:
           
     - name: Build
       run: |
-           FOAM_VERBOSE=true source /openfoam/etc/bashrc 
+           FOAM_VERBOSE=true 
            source etc-mingw/prefs.sh
+           source /openfoam/etc/bashrc           
            ls
            pwd
            ls /openfoam

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -65,4 +65,4 @@ jobs:
            pwd
            ls /openfoam
            source /openfoam/etc/bashrc etc-mingw/prefs.sh
-           ./Allwmake -j
+           Allwmake -j

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -61,6 +61,8 @@ jobs:
           
     - name: Build
       run: |    
-           FOAM_VERBOSE=true &&  source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh && ls && ./Allwmake -j
-      
-      shell: sh
+           FOAM_VERBOSE=true &&  source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh && ls && ./Allwmake -j      
+      shell: sh      
+      artifacts:
+        paths:
+          - /root/OpenFOAM/-v2106/platforms/linux64MingwDPInt32Opt/

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -70,4 +70,5 @@ jobs:
            pwd
            ls /openfoam
            echo $FOAM_SETTINGS
-           ./Allwmake -j
+           ./Allwmake -j      
+      shell: bash

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -31,7 +31,7 @@ jobs:
       uses: docker/build-push-action@v1
       with:
         registry: ghcr.io
-        repository: pmf/opensuse-mingw
+        repository: jmkerloch/openfoam-opensuse-mingw
         tags: latest
         dockerfile: docker/opensuse-mingw
 
@@ -39,7 +39,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: docker_publish
-    container: 'pmf/opensuse-mingw'
+    container: 'jmkerloch/openfoam-opensuse-mingw'
 
     steps:
     

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -61,7 +61,6 @@ jobs:
           
     - name: Build
       run: |           
-           source etc-mingw/prefs.sh
            echo $FOAM_CONFIG_ETC
            echo $WM_COMPILER
            echo $WM_MPLIB          

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -61,9 +61,9 @@ jobs:
           
     - name: Build
       run: |
+           FOAM_VERBOSE=true source /openfoam/etc/bashrc etc-mingw/prefs.sh
            ls
            pwd
            ls /openfoam
-           source /openfoam/etc/bashrc etc-mingw/prefs.sh
            echo $FOAM_SETTINGS
            ./Allwmake -j

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -62,4 +62,6 @@ jobs:
     - name: Build
       run: |
            source /openfoam/etc/bashrc etc-mingw/prefs.sh
+           ls
+           pwd
            ./Allwmake -j

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Push to GitHub Packages
       uses: docker/build-push-action@v1
       with:
+        registry: ghcr.io
         tags: openfoam-opensuse-mingw
         dockerfile: docker/opensuse-mingw
 

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -1,0 +1,61 @@
+name: OpenSuse mingw CI (docker image)
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - features/*
+      - feature/
+  
+jobs:
+
+  docker_publish:
+          
+    runs-on: ubuntu-latest
+    
+    steps:
+    
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 0
+        
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v1.1.2
+      with:
+        files: |
+          docker/opensuse-mingw
+        
+    - name: Docker file push
+      id: docker_push
+      if: steps.changed-files.outputs.modified_files != ''
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: jmkerloch/openfoam-opensuse-mingw
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        workdir: docker
+        dockerfile: opensuse-mingw
+        cache: true
+        tags: opensuse-mingw
+
+  build:
+
+    runs-on: ubuntu-latest
+    needs: docker_publish
+    container: 'jmkerloch/openfoam-opensuse-mingw'
+
+    steps:
+    
+    - uses: nelonoel/branch-name@v1.0.1
+    
+    - name: Checkout
+      run: |
+          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git -b ${BRANCH_NAME} .
+          
+    - name: Configure
+      run: |
+           source /etc-mingw/prefs.sh
+           ./Allwmake -j
+

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -61,9 +61,10 @@ jobs:
           
     - name: Build
       run: |    
+           export PMF_DIR=$pwd
            FOAM_VERBOSE=true
-           cd openfoam
+           cd /openfoam
            FOAM_VERBOSE=true  source etc/bashrc etc-mingw/prefs.sh
-           cd ..
+           cd $PMF_DIR
            ./Allwmake -j      
       shell: bash

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -26,6 +26,13 @@ jobs:
       with:
         files: |
           docker/opensuse-mingw
+          
+    - name: Log in to the Container registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
         
     - name: Push to GitHub Packages
       uses: docker/build-push-action@v1

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -60,7 +60,6 @@ jobs:
     - name: Build
       run: |
            pwd
-	   ls -l
+           ls -l
            source /etc-mingw/prefs.sh
            ./Allwmake -j
-

--- a/docker/opensuse-mingw
+++ b/docker/opensuse-mingw
@@ -15,6 +15,5 @@ ADD etc-mingw  openfoam/etc-mingw
 RUN zypper install -y make gcc gcc-c++ m4 flex
 RUN cd openfoam &&\
     FOAM_VERBOSE=true  &&\
-    source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh &&\
-    ./Allwmake -j
+    source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh
 

--- a/docker/opensuse-mingw
+++ b/docker/opensuse-mingw
@@ -1,0 +1,21 @@
+FROM opensuse/leap
+
+RUN zypper in mingw64-cross-binutils
+RUN zypper in mingw64-cross-cpp mingw64-cross-gcc mingw64-cross-gcc-c++
+RUN zypper in mingw64-filesystem mingw64-headers mingw64-runtime
+
+RUN zypper in mingw64-libwinpthread1 mingw64-winpthreads-devel
+RUN zypper in mingw64-libz mingw64-zlib-devel
+
+# Note: can cross-compile FFTW from ThirdParty sources instead
+RUN zypper in mingw64-libfftw3 mingw64-fftw3-devel
+
+RUN zypper in git
+
+RUN git clone https://develop.openfoam.com/Development/openfoam.git
+ADD ../etc-mingw  openfoam/etc-mingw
+
+RUN cd openfoam
+RUN FOAM_VERBOSE=true  source etc/bashrc etc-mingw/prefs.sh
+RUN ./Allwmake -j
+

--- a/docker/opensuse-mingw
+++ b/docker/opensuse-mingw
@@ -15,5 +15,6 @@ ADD etc-mingw  openfoam/etc-mingw
 RUN zypper install -y make gcc gcc-c++ m4 flex
 RUN cd openfoam &&\
     FOAM_VERBOSE=true  &&\
-    source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh
+    source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh &&\
+    ./Allwmake -j
 

--- a/docker/opensuse-mingw
+++ b/docker/opensuse-mingw
@@ -1,21 +1,20 @@
 FROM opensuse/leap
 
-RUN zypper in mingw64-cross-binutils
-RUN zypper in mingw64-cross-cpp mingw64-cross-gcc mingw64-cross-gcc-c++
-RUN zypper in mingw64-filesystem mingw64-headers mingw64-runtime
+RUN zypper install -y mingw64-cross-binutils
+RUN zypper install -y mingw64-cross-cpp mingw64-cross-gcc mingw64-cross-gcc-c++
+RUN zypper install -y mingw64-filesystem mingw64-headers mingw64-runtime
 
-RUN zypper in mingw64-libwinpthread1 mingw64-winpthreads-devel
-RUN zypper in mingw64-libz mingw64-zlib-devel
+RUN zypper install -y mingw64-libwinpthread1 mingw64-winpthreads-devel
+RUN zypper install -y mingw64-libz mingw64-zlib-devel
 
-# Note: can cross-compile FFTW from ThirdParty sources instead
-RUN zypper in mingw64-libfftw3 mingw64-fftw3-devel
-
-RUN zypper in git
+RUN zypper install -y git
 
 RUN git clone https://develop.openfoam.com/Development/openfoam.git
-ADD ../etc-mingw  openfoam/etc-mingw
+ADD etc-mingw  openfoam/etc-mingw
 
-RUN cd openfoam
-RUN FOAM_VERBOSE=true  source etc/bashrc etc-mingw/prefs.sh
-RUN ./Allwmake -j
+RUN zypper install -y make gcc gcc-c++ m4 flex
+RUN cd openfoam &&\
+    FOAM_VERBOSE=true  &&\
+    source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh &&\
+    ./Allwmake -j
 

--- a/etc-mingw/prefs.sh
+++ b/etc-mingw/prefs.sh
@@ -1,0 +1,6 @@
+# Preferences for mingw cross-compiled
+
+export FOAM_CONFIG_ETC="etc-mingw"
+export WM_COMPILER=Mingw
+export WM_MPLIB=
+

--- a/libraries/porousModels/Make/options
+++ b/libraries/porousModels/Make/options
@@ -13,3 +13,12 @@ EXE_LIBS = \
     -lfluidThermophysicalModels \
     -lreactionThermophysicalModels \
     -ltoolsGIS
+
+LIB_LIBS = \
+    -L$(FOAM_USER_LIBBIN) \
+    -lfiniteVolume \
+    -lspecie \
+    -lfluidThermophysicalModels \
+    -lreactionThermophysicalModels \
+    -ltoolsGIS
+

--- a/libraries/toolsGIS/Make/options
+++ b/libraries/toolsGIS/Make/options
@@ -4,3 +4,7 @@ EXE_INC = \
 
 EXE_LIBS = \
     -lfiniteVolume
+
+LIB_LIBS = \
+    -lfiniteVolume
+


### PR DESCRIPTION
I'm working for Oslandia and we are using PMF in THYRSIS project for CEA. We are looking for a simplier way of using PMF and openfoam on Windows. Since openfoam.com provides pre-compiled binaries for windows (https://develop.openfoam.com/Development/openfoam/-/wikis/precompiled/windows), we will be using these binaries but we must also build PMF with mingw.

This PR provide build with mingw on opensus of PMF and provide an artifact with pre-compiled binaries.

This is done with a docker image building openfoam on mingw :
- add a dockerfile for openfoam build
- build and push docker image to github container registry associated with pmf repository

The docker image is then used to build pmf and the pre-compiled binaries are provided as artifact.

:warning: **Since the docker image was push to @jmkerloch repository, docker build and push action must be forced by adding a line in dockerfile.** :warning: 

This is the first PR, we must also think about another PR which will provide the artifact as a release for PMF.

Note : 
> This PR come from dev branch but can be used for other PMF branches. For THYRSIS we need OpenFOAM-v2106