### PR TITLE
Feature/opensuse mingw openfoam 2106

### DIFF
--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -44,7 +44,7 @@ jobs:
         dockerfile: docker/opensuse-mingw
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        build-args: OPENFOAM_BRANCH=maintenance-v2106
+        build_args: OPENFOAM_BRANCH=maintenance-v2106
 
   build:
 

--- a/.github/workflows/opensuse-mingw.yml
+++ b/.github/workflows/opensuse-mingw.yml
@@ -1,0 +1,72 @@
+name: OpenSuse mingw CI (docker image)
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - features/*
+      - feature/*
+  
+jobs:
+
+  docker_publish:
+          
+    runs-on: ubuntu-latest
+    
+    steps:
+    
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 0
+        
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v1.1.2
+      with:
+        files: |
+          docker/opensuse-mingw
+          
+    - name: Log in to the Container registry
+      #if: steps.changed-files.outputs.modified_files != ''
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Push to GitHub Packages
+      #if: steps.changed-files.outputs.modified_files != ''
+      uses: docker/build-push-action@v1
+      with:
+        registry: ghcr.io
+        tags: openfoam-v2106-opensuse-mingw
+        dockerfile: docker/opensuse-mingw
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        build-args: OPENFOAM_BRANCH=maintenance-v2106
+
+  build:
+
+    runs-on: ubuntu-latest
+    needs: docker_publish
+    container: 'ghcr.io/${{github.actor}}/porousmultiphasefoam:openfoam-v2106-opensuse-mingw'
+
+    steps:
+    
+    - uses: nelonoel/branch-name@v1.0.1
+    
+    - name: Checkout
+      run: |
+          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git -b ${BRANCH_NAME} .
+          
+    - name: Build
+      run: |    
+           FOAM_VERBOSE=true &&  source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh && ls && ./Allwmake -j
+      
+    - name: Build artifact upload
+      uses: actions/upload-artifact@v2
+      with:
+        name: pmf-opensuse-mingw
+        path: /github/home/OpenFOAM/-v2106/platforms/linux64MingwDPInt32Opt/
+        

--- a/docker/opensuse-mingw
+++ b/docker/opensuse-mingw
@@ -1,0 +1,22 @@
+FROM opensuse/leap
+
+ARG OPENFOAM_BRANCH=maintenance-v2106
+
+RUN zypper install -y mingw64-cross-binutils
+RUN zypper install -y mingw64-cross-cpp mingw64-cross-gcc mingw64-cross-gcc-c++
+RUN zypper install -y mingw64-filesystem mingw64-headers mingw64-runtime
+
+RUN zypper install -y mingw64-libwinpthread1 mingw64-winpthreads-devel
+RUN zypper install -y mingw64-libz mingw64-zlib-devel
+
+RUN zypper install -y git
+
+RUN git clone -b $OPENFOAM_BRANCH https://develop.openfoam.com/Development/openfoam.git
+ADD etc-mingw  openfoam/etc-mingw
+
+RUN zypper install -y make gcc gcc-c++ m4 flex
+RUN cd openfoam &&\
+    FOAM_VERBOSE=true  &&\
+    source /openfoam/etc/bashrc /openfoam/etc-mingw/prefs.sh &&\
+    ./Allwmake -j
+

--- a/etc-mingw/prefs.sh
+++ b/etc-mingw/prefs.sh
@@ -1,0 +1,6 @@
+# Preferences for mingw cross-compiled
+
+export FOAM_CONFIG_ETC="etc-mingw"
+export WM_COMPILER=Mingw
+export WM_MPLIB=
+

--- a/libraries/porousModels/Make/options
+++ b/libraries/porousModels/Make/options
@@ -13,3 +13,12 @@ EXE_LIBS = \
     -lfluidThermophysicalModels \
     -lreactionThermophysicalModels \
     -ltoolsGIS
+
+LIB_LIBS = \
+    -L$(FOAM_USER_LIBBIN) \
+    -lfiniteVolume \
+    -lspecie \
+    -lfluidThermophysicalModels \
+    -lreactionThermophysicalModels \
+    -ltoolsGIS
+

--- a/libraries/toolsGIS/Make/options
+++ b/libraries/toolsGIS/Make/options
@@ -4,3 +4,7 @@ EXE_INC = \
 
 EXE_LIBS = \
     -lfiniteVolume
+
+LIB_LIBS = \
+    -lfiniteVolume
+


### PR DESCRIPTION
I'm working for Oslandia and we are using PMF in THYRSIS project for CEA. We are looking for a simplier way of using PMF and openfoam on Windows. Since openfoam.com provides pre-compiled binaries for windows (https://develop.openfoam.com/Development/openfoam/-/wikis/precompiled/windows), we will be using these binaries but we must also build PMF with mingw.

This PR provide build with mingw on opensus of PMF and provide an artifact with pre-compiled binaries.

This is done with a docker image building openfoam on mingw :
- add a dockerfile for openfoam build
- build and push docker image to github container registry associated with pmf repository

The docker image is then used to build pmf and the pre-compiled binaries are provided as artifact.

:warning: **After merge a new commit must be added to avoid docker build at each commit
Decomment       `#if: steps.changed-files.outputs.modified_files != '' `in `opensuse-mingw.yml`** :warning: 

This is the first PR, we must also think about another PR which will provide the artifact as a release for PMF.