### PR TITLE
Fix compatibility with OpenFOAM v2112

### DIFF
--- a/libraries/numericalMethods/Make/options
+++ b/libraries/numericalMethods/Make/options
@@ -1,5 +1,7 @@
 EXE_INC = \
-    -I$(LIB_SRC)/finiteVolume/lnInclude
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude
 
 LIB_LIBS = \
-    -lfiniteVolume
+    -lfiniteVolume \
+    -lmeshTools

--- a/libraries/porousModels/capillarityModels/capillarityModel/capillarityModelNew.C
+++ b/libraries/porousModels/capillarityModels/capillarityModel/capillarityModelNew.C
@@ -42,8 +42,7 @@ Foam::autoPtr<Foam::capillarityModel> Foam::capillarityModel::New
 
   Info<< "Selecting capillarity model => " << modelType << "\n" << endl;
 
-  dictionaryConstructorTable::iterator cstrIter =
-    dictionaryConstructorTablePtr_->find(modelType);
+  auto cstrIter = dictionaryConstructorTablePtr_->find(modelType);
 
   if (cstrIter == dictionaryConstructorTablePtr_->end())
     {

--- a/libraries/porousModels/dispersionModels/dispersionModel/dispersionModelNew.C
+++ b/libraries/porousModels/dispersionModels/dispersionModel/dispersionModelNew.C
@@ -42,8 +42,7 @@ Foam::autoPtr<Foam::dispersionModel> Foam::dispersionModel::New
 
     Info<< "Selecting dispersion model => " << modelType << "\n" << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
-        dictionaryConstructorTablePtr_->find(modelType);
+    auto cstrIter = dictionaryConstructorTablePtr_->find(modelType);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())
     {

--- a/libraries/porousModels/relativePermeabilityModels/relativePermeabilityModel/relativePermeabilityModelNew.C
+++ b/libraries/porousModels/relativePermeabilityModels/relativePermeabilityModel/relativePermeabilityModelNew.C
@@ -42,8 +42,7 @@ Foam::autoPtr<Foam::relativePermeabilityModel> Foam::relativePermeabilityModel::
 
     Info<< "Selecting relativePermeability model => " << modelType << "\n" << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
-        dictionaryConstructorTablePtr_->find(modelType);
+    auto cstrIter = dictionaryConstructorTablePtr_->find(modelType);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())
     {


### PR DESCRIPTION
- Link numericalMethods library to meshTools (fixes `... cyclicAMI*.H [...] : No such file or directory` build errors)
- [Update `cstrIter` type declarations](https://develop.openfoam.com/Development/openfoam/-/wikis/upgrade/v2112-Developer-Upgrade-Guide#potential-breaking-changes)

Tested with v2106 and v2112.

EDIT: fix link