### PR TITLE
Replace call to deprecated tmp::empty() with bool evaluation

### DIFF
--- a/libraries/toolsGIS/eventFile/eventFile.C
+++ b/libraries/toolsGIS/eventFile/eventFile.C
@@ -210,7 +210,7 @@ void Foam::eventFile::setTimeScheme(const word& dtFieldName, const fvMesh& mesh)
 
 Foam::scalar Foam::eventFile::dtValue(const label& id) const
 {
-    if(ddtScheme_.empty())
+    if(!ddtScheme_)
     {
         FatalErrorIn("eventFile.C")
             << "You must call setTimeScheme(...) before being able to use dtValue(s)()"


### PR DESCRIPTION
Fixes this deprecation warning:
```bash
eventFile/eventFile.C:213:19: warning: 'empty' is deprecated: Since 2020-07; use "bool operator" [-Wdeprecated-declarations]
    if(ddtScheme_.empty())
                  ^
/Volumes/OpenFOAM-v2112/src/OpenFOAM/lnInclude/tmp.H:301:9: note: 'empty' has been explicitly marked deprecated here
```