### PR TITLE
Fix compatibility with OpenFOAM v2212

### DIFF
--- a/solvers/groundwaterFoam/groundwaterFoam.C
+++ b/solvers/groundwaterFoam/groundwaterFoam.C
@@ -143,7 +143,11 @@ noConvergence :
             runTime.write();
             if (writeResiduals)
             {
+#if OPENFOAM >= 2212
+                OFstream residualFile("residuals.csv", IOstreamOption(), IOstreamOption::APPEND);
+#else
                 OFstream residualFile("residuals.csv", IOstreamOption(), true);
+#endif
                 residualFile << runTime.timeName() << " " << mag(hEqnResidual) << endl;
             }
             if (hEqnResidual < tolerancePicard) runTime.writeAndEnd();


### PR DESCRIPTION
Not the prettiest of fixes, but OpenFOAM v2212 [changed the constructors of `OFstream` in a fully incompatible way]( https://develop.openfoam.com/Development/openfoam/-/wikis/upgrade/v2212-Developer-Upgrade-Guide#enumerated-appendnon-append-open-file).
