### PR TITLE
Fixes: derivative of krb and bounded saturation equation

### DIFF
--- a/libraries/porousModels/relativePermeabilityModels/BrooksAndCorey/krBrooksAndCorey.C
+++ b/libraries/porousModels/relativePermeabilityModels/BrooksAndCorey/krBrooksAndCorey.C
@@ -157,7 +157,7 @@ void Foam::relativePermeabilityModels::krBrooksAndCorey::correctkrb(const volSca
     krb_ = krbmax_ * pow(Se_,n_);
     if (derivative)
     {
-        dkradS_ = -kramax_*n_*pow((scalar(1)-Se_),n_-1)/(Smax_- Smin_);
+        dkrbdS_ = krbmax_*n_*pow(Se_,n_-1)/(Smax_- Smin_);
     }
 }
 void Foam::relativePermeabilityModels::krBrooksAndCorey::correctkrb(const volScalarField& Sb, const label& celli)

--- a/solvers/impesFoam/SEqn.H
+++ b/solvers/impesFoam/SEqn.H
@@ -16,13 +16,15 @@
   
     fvScalarMatrix SbEqn
         (
-            eps*fvm::ddt(Sb) + fvc::div(phib) 
+            // eps*fvm::ddt(Sb) + fvc::div(phib)
+            eps*fvm::ddt(Sb) + fvm::div(phib, Sb) 
             ==
             // event source terms
             - sourceTerm
         );
 
     SbEqn.solve();
+    Sb.correctBoundaryConditions();
 
     Info << "Saturation b: " << " Min(Sb) = " << gMin(Sb) << " Max(Sb) = " << gMax(Sb) << endl;
 


### PR DESCRIPTION
- derivative of krb in krBrooksAndCorey.C  was the same as the one defined for kra;
- saturation Sb drops below Sbmin in heterogeneous K fields and code crashes. Testing alternatives for saturation equation in SEqn.H: fvc::div(phib) -> fvm::div(phib, Sb)